### PR TITLE
Update usage of typed-scss-modules in index.mdx for lib-vite-tailwindcss

### DIFF
--- a/posts/lib-vite-tailwindcss/index.mdx
+++ b/posts/lib-vite-tailwindcss/index.mdx
@@ -394,7 +394,7 @@ The CLI interface is pretty same.
   <CodeGroup label="Yarn" active>
 
 ```bash
-yarn tsm src
+yarn typed-scss-modules src
 ```
 
   </CodeGroup>
@@ -402,7 +402,7 @@ yarn tsm src
   <CodeGroup label="NPM">
 
 ```bash
-npm run tsm src
+npx typed-scss-modules src
 ```
 
   </CodeGroup>


### PR DESCRIPTION
Update usage of `typed-scss-modules` in `index.mdx` for `lib-vite-tailwindcss`.